### PR TITLE
Adapted to the new version rofi 1.7.0

### DIFF
--- a/config.rasi
+++ b/config.rasi
@@ -3,7 +3,7 @@
 * {
     font: "Jetbrains Mono 12";
     foreground: #f8f8f2;
-    background-color: #282a36;
+    background: #282a36;
     active-background: #6272a4;
     urgent-background: #ff5555;
     selected-background: @active-background;


### PR DESCRIPTION
In the new 1.7.0 version, the background color could not display properly. I modified to adapt the new version