### PR TITLE
Fixed urgent-foreground

### DIFF
--- a/theme/config1.rasi
+++ b/theme/config1.rasi
@@ -6,6 +6,7 @@
     background-color: #282a36;
     active-background: #6272a4;
     urgent-background: #ff5555;
+    urgent-foreground: #282a36;
     selected-background: @active-background;
     selected-urgent-background: @urgent-background;
     selected-active-background: @active-background;

--- a/theme/config2.rasi
+++ b/theme/config2.rasi
@@ -18,6 +18,7 @@
     background-color: @drac-bgd;
     active-background: @drac-pnk;
     urgent-background: @drac-red;
+    urgent-foreground: @drac-bgd;
     
     selected-background: @active-background;
     selected-urgent-background: @urgent-background;


### PR DESCRIPTION
This should fix #12.

In both themes the variable `urgent-foreground` is referenced. This variable is never declared and can be easily fixed.

 (This has nothing to do with the API of rofi, and I guess that it only came up recently, because rofi might have introduced a validator for the themes, and it would have just failed silently before - but I'm 100% sure on that)


In my fork i used the dracula background color as foreground, because I think black on red is easier on the eyes than white on red. (Also, if urgent-foreground was left undeclared, the color would have defaulted to black anyways, so this way there is little to no difference for anyone who has seen urgent lines before)

This is a screenshot of how this PR would look like.

![image](https://user-images.githubusercontent.com/43534802/185396150-412c75a4-2742-4021-a109-08238f77f5da.png)

And here is the script to reproduce the screenshot: 
```bash
#!/bin/bash
echo -en "Not Urgent\n"
echo -en "Not Urgent\n"
echo -en "Not Urgent\n"
echo -en "Not Urgent\n"
echo -en "Not Urgent\n"
echo -en "Not Urgent\n"
echo -en "Not Urgent\n"
echo -en "Not Urgent\n"
echo -en "Very Urgent\n"
echo -en "Not Urgent\n"
echo -en "Not Urgent\n"
echo -en "Not Urgent\n"
echo -en "\0urgent\x1f8\n"
```
Which can be executed using `rofi -show fb -modes "fb:/tmp/testurgent.sh"` Assuming the script is located at `/tmp/testurgent.sh`

More info on the urgent api can be found [here](https://github.com/davatorium/rofi/blob/8e8765e2ce36622e50f0cb5d1f06bd9eb374bdf4/doc/rofi-script.5.markdown#passing-mode-options)